### PR TITLE
Update to OWLAPI 4.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,9 +57,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <ontology-core.version>2.8.1</ontology-core.version>
-        <owl-api.version>3.3</owl-api.version>
-        <protege.version>4.1.0</protege.version>
+        <ontology-core.version>2.9.0-SNAPSHOT</ontology-core.version>
+        <owl-api.version>[4.0.2,4.1)</owl-api.version>
+        <protege.version>5.0.0-beta-18-SNAPSHOT</protege.version>
         <sl4j.version>1.7.10</sl4j.version>
     </properties>
     

--- a/snorocket-owlapi/pom.xml
+++ b/snorocket-owlapi/pom.xml
@@ -45,22 +45,7 @@
     </dependency>
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
-      <artifactId>owlapi-api</artifactId>
-      <version>${owl-api.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>net.sourceforge.owlapi</groupId>
-      <artifactId>owlapi-apibinding</artifactId>
-      <version>${owl-api.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>net.sourceforge.owlapi</groupId>
-      <artifactId>owlapi-reasoner</artifactId>
-      <version>${owl-api.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>net.sourceforge.owlapi</groupId>
-      <artifactId>owlapi-mansyntax</artifactId>
+      <artifactId>owlapi-osgidistribution</artifactId>
       <version>${owl-api.version}</version>
     </dependency>
   </dependencies>

--- a/snorocket-owlapi/src/main/java/au/csiro/snorocket/owlapi/util/DebugUtils.java
+++ b/snorocket-owlapi/src/main/java/au/csiro/snorocket/owlapi/util/DebugUtils.java
@@ -28,6 +28,7 @@ import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
 import org.semanticweb.owlapi.model.OWLSubObjectPropertyOfAxiom;
 import org.semanticweb.owlapi.model.OWLSubPropertyChainOfAxiom;
+import org.semanticweb.owlapi.search.EntitySearcher;
 
 /**
  * @author Alejandro Metke
@@ -94,7 +95,7 @@ public class DebugUtils {
     }
 
     public static String getLabel(OWLEntity e, OWLOntology ont) {
-        for (OWLAnnotation an : e.getAnnotations(ont)) {
+        for (OWLAnnotation an : EntitySearcher.getAnnotations(e, ont)) {
             if (an.getProperty().isLabel()) {
                 OWLAnnotationValue val = an.getValue();
 

--- a/snorocket-protege/pom.xml
+++ b/snorocket-protege/pom.xml
@@ -38,23 +38,18 @@
     </dependency>
     <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
-      <artifactId>owlapi-reasoner</artifactId>
+      <artifactId>owlapi-osgidistribution</artifactId>
       <version>${owl-api.version}</version>
     </dependency>
     <dependency>
-      <groupId>net.sourceforge.owlapi</groupId>
-      <artifactId>owlapi-apibinding</artifactId>
-      <version>${owl-api.version}</version>
+    	<groupId>edu.stanford.protege</groupId>
+    	<artifactId>org.protege.editor.core.application</artifactId>
+    	<version>${protege.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.protege</groupId>
-      <artifactId>protege-editor-owl</artifactId>
-      <version>${protege.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.protege</groupId>
-      <artifactId>protege-editor-core-application</artifactId>
-      <version>${protege.version}</version>
+    	<groupId>edu.stanford.protege</groupId>
+    	<artifactId>org.protege.editor.owl</artifactId>
+    	<version>${protege.version}</version>
     </dependency>
   </dependencies>
 

--- a/snorocket-protege/src/main/java/au/csiro/snorocket/protege/ProtegeReasonerFactory.java
+++ b/snorocket-protege/src/main/java/au/csiro/snorocket/protege/ProtegeReasonerFactory.java
@@ -31,13 +31,14 @@ public class ProtegeReasonerFactory extends AbstractProtegeOWLReasonerInfo {
     }
 
     @Override
-    public void initialise() throws Exception {
+    public void initialise() {
         
     }
 
     @Override
-    public void dispose() throws Exception {
-        
+    public void dispose() {
+        factory = null;
     }
+
 
 }

--- a/snorocket-protege/src/main/java/au/csiro/snorocket/protege/util/DebugUtils.java
+++ b/snorocket-protege/src/main/java/au/csiro/snorocket/protege/util/DebugUtils.java
@@ -28,6 +28,7 @@ import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
 import org.semanticweb.owlapi.model.OWLSubObjectPropertyOfAxiom;
 import org.semanticweb.owlapi.model.OWLSubPropertyChainOfAxiom;
+import org.semanticweb.owlapi.search.EntitySearcher;
 
 /**
  * @author Alejandro Metke
@@ -94,7 +95,7 @@ public class DebugUtils {
     }
 
     public static String getLabel(OWLEntity e, OWLOntology ont) {
-        for (OWLAnnotation an : e.getAnnotations(ont)) {
+        for (OWLAnnotation an : EntitySearcher.getAnnotations(e, ont)) {
             if (an.getProperty().isLabel()) {
                 OWLAnnotationValue val = an.getValue();
 


### PR DESCRIPTION
This is an update to allow Snorocket to work in Protege 5 beta 18 and newer, with OWLAPI 4.0.2 and newer.
This is for local development only at this point, as OWLAPI and Protege versions have not been released yet.